### PR TITLE
Fix model serving endpoint URL missing /api/2.0 prefix

### DIFF
--- a/nodes/Databricks/resources/modelServing.ts
+++ b/nodes/Databricks/resources/modelServing.ts
@@ -92,7 +92,7 @@ export const modelServingOperations: INodeProperties = {
             routing: {
                 request: {
                     method: 'POST',
-                    url: '/serving-endpoints/{{$parameter.endpointName}}/invocations',
+                    url: '/api/2.0/serving-endpoints/={{$parameter.endpointName}}/invocations',
                     body: {
                         inputs: '={{$parameter.inputs}}',
                     },


### PR DESCRIPTION
- Fixed Query Endpoint operation URL in modelServing.ts
- This resolves the issue where model serving queries return empty results